### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-json-nest2flat
+# fluent-plugin-json-nest, a plugin for [Fluentd](http://fluentd.org)2flat
 # Overview
 
 json_nest2flat is a fluentd output plugin.I will convert data into a flat data structure of JSON nested.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-json-nest, a plugin for [Fluentd](http://fluentd.org)2flat
+# fluent-plugin-json-nest2flat, a plugin for [Fluentd](http://fluentd.org)
 # Overview
 
 json_nest2flat is a fluentd output plugin.I will convert data into a flat data structure of JSON nested.


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
