### PR TITLE
Fix to work well even if ignore_item_keys is null.

### DIFF
--- a/lib/fluent/plugin/out_json_nest2flat.rb
+++ b/lib/fluent/plugin/out_json_nest2flat.rb
@@ -71,12 +71,14 @@ module Fluent
                 if @json_keys.include?(old_record_k)
                     json_data = old_record[old_record_k]
                     JSON.parse(json_data).each { |json_k, json_v|
-                        if @ignore_item_keys.include?(old_record_k)
-                            # 無視するキーに該当
-                            ignore_items = @ignore_item_keys[old_record_k]
-                            if ignore_items.include?(json_k)
-                                # 無視するアイテムに該当するのでハッシュに含まない
-                                next
+                        if !@ignore_item_keys.nil?
+                            if @ignore_item_keys.include?(old_record_k)
+                                # 無視するキーに該当
+                                ignore_items = @ignore_item_keys[old_record_k]
+                                if ignore_items.include?(json_k)
+                                    # 無視するアイテムに該当するのでハッシュに含まない
+                                    next
+                                end
                             end
                         end
                         new_record[json_k] = json_v


### PR DESCRIPTION
If ignore_item_keys is null, json-nest2flat failed to parse a log message. I fixed it.
